### PR TITLE
Enable setting UUID var name and passing in

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -5,7 +5,7 @@ set -e
 TAG=ngx
 PORT=8443
 START_INSTANCE="docker run "
-DOCKER_HOST_NAME=127.0.0.1
+DOCKER_HOST_NAME=${DOCKER_HOST_NAME:-'127.0.0.1'}
 MUTUAL_TLS="mutual-tls"
 STANDARD_TLS="standard-tls"
 
@@ -409,7 +409,6 @@ echo "Testing json logs format..."
 docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 docker logs ${INSTANCE}  | grep 'animal=cow'
 
-
 start_test "Test param logging off option works..." "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \
@@ -503,6 +502,28 @@ if curl -k https://${DOCKER_HOST_NAME}:${PORT}/\?\"==\` | grep "Sorry, we are re
 else
   echo "Testing VERBOSE_ERROR_PAGES works..."
 fi
+
+start_test "Test setting UUID name works..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=custom_uuid_name\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "custom_uuid_name"
+echo "Testing setting UUID_VAR_NAME works"
+
+start_test "Test setting empty UUID name defaults correctly..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"ENABLE_UUID_PARAM=HEADER\" \
+           -e \"UUID_VAR_NAME=\" \
+           --link mockserver:mockserver "
+curl -sk https://${DOCKER_HOST_NAME}:${PORT}
+docker logs mockserver 2>/dev/null | grep "nginxId"
+echo "Testing UUID_VAR_NAME default if empty works"
 
 echo "_________________________________"
 echo "We got here, ALL tests successful"

--- a/defaults.sh
+++ b/defaults.sh
@@ -2,6 +2,7 @@
 export NGIX_CONF_DIR=/usr/local/openresty/nginx/conf
 export NGINX_BIN=/usr/local/openresty/nginx/sbin/nginx
 export UUID_FILE=/tmp/uuid_on
+export UUID_VAR_NAME=${UUID_VAR_NAME:-'nginxId'}
 export DEFAULT_ERROR_CODES="500 501 502 503 504"
 export LOG_FORMAT_NAME=${LOG_FORMAT_NAME:-json}
 export SERVER_CERT=${SERVER_CERT:-/etc/keys/crt}

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -147,12 +147,12 @@ if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
     UUID_ARGS=''
     msg "Auto UUID request parameter disabled for location ${LOCATION_ID}."
 elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
-    UUID_ARGS='proxy_set_header nginxId $uuidopt;'
+    UUID_ARGS="proxy_set_header ${UUID_VAR_NAME} \$uuidopt;"
     # Ensure nginx enables this globaly
     msg "Auto UUID request header enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}
 else
-    UUID_ARGS='if ($is_args) {set $args $args&nginxId=$uuidopt;} if ($is_args = "") { set $args nginxId=$uuidopt;}'
+    UUID_ARGS="if (\$is_args) {set \$args \$args&${UUID_VAR_NAME}=\$uuidopt;} if (\$is_args = \"\") { set \$args ${UUID_VAR_NAME}=\$uuidopt;}"
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -6,6 +6,7 @@ else
     uuid.randomseed(socket.gettime()*10000)
     local uuid_str = uuid()
     ngx.var.uuid = uuid_str
-    ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
+    local uuid_var_name = os.getenv("UUID_VAR_NAME")
+    ngx.var.uuid_log_opt = " " .. uuid_var_name .. "=" .. uuid_str
     return uuid_str
 end

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,7 @@
 error_log /dev/stderr error;
 
 env LOG_UUID;
+env UUID_VAR_NAME;
 env HTTPS_REDIRECT_PORT_STRING;
 env ALLOW_COUNTRY_CSV;
 env VERBOSE_ERROR_PAGES;


### PR DESCRIPTION
Pay historically use X-Request-Id as our uuid header. This gets passed
to applications, which send it on to any upstream services. This is set
in every microservice we have. Rather than change them all to use
nginxId, enable passing in an arbitrary uuid var name. Defaults to
nginxId so shouldn’t effect current behaviour.