### PR TITLE
PP-2599 Custom logging format

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -409,6 +409,18 @@ echo "Testing json logs format..."
 docker logs ${INSTANCE}  | grep '{"proxy_proto_address":'
 docker logs ${INSTANCE}  | grep 'animal=cow'
 
+start_test "Test custom logging format..." "${STD_CMD} \
+           -e \"PROXY_SERVICE_HOST=http://mockserver\" \
+           -e \"PROXY_SERVICE_PORT=8080\" \
+           -e \"DNSMASK=TRUE\" \
+           -e \"LOG_FORMAT_NAME=custom\" \
+           -e \"CUSTOM_LOG_FORMAT=' \\\$host:\\\$server_port \\\$uuid \\\$http_x_forwarded_for \\\$remote_addr \\\$remote_user [\\\$time_local] \\\$request \\\$status \\\$body_bytes_sent \\\$request_time \\\$http_x_forwarded_proto \\\$http_referer \\\$http_user_agent '\" \
+           -e \"ENABLE_UUID_PARAM=FALSE\" \
+           --link mockserver:mockserver "
+wget -O /dev/null --quiet --no-check-certificate --header="Host: example.com" https://${DOCKER_HOST_NAME}:${PORT}?animal=cow
+echo "Testing custom logs format..."
+docker logs ${INSTANCE} | egrep '^\{\sexample\.com:10443.*\[.*\]\sGET\s\/\?animal\=cow\sHTTP/1\.\d\s200.*\s\}$'
+
 start_test "Test param logging off option works..." "${STD_CMD} \
            -e \"PROXY_SERVICE_HOST=http://mockserver\" \
            -e \"PROXY_SERVICE_PORT=8080\" \


### PR DESCRIPTION
In order to use  UKHomeOffice/docker-nginx-proxy as our nginx
container we need to be able to specifiy the logging format
to maiantain backwards compatibility with rest of platform.

This commit is Josh's work on custom log format, and I have added
a test showing how we can pass in our current format.

Need to check if host header would be set correctly by
upstream services