### PR TITLE
[WIP] PP-2604 AWS Region is now passed as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Note the following variables can only be set once:
 [Arbitrary Config](#arbitrary-config)
 * `ADD_NGINX_HTTP_CFG` - Arbitrary extra NGINX configuration to be added to the http context, see
 [Arbitrary Config](#arbitrary-config)
+* `AWS_REGION` - Sets the AWS region this container is running in. Used to construct urls from which to download resources from. Defaults to 'eu-west-1' if not set.
 * `LOCATIONS_CSV` - Set to a list of locations that are to be independently proxied, see the example
 [Using Multiple Locations](#using-multiple-locations). Note, if this isn't set, `/` will be used as the default
 location.

--- a/defaults.sh
+++ b/defaults.sh
@@ -17,6 +17,7 @@ export NO_LOGGING_BODY=${NO_LOGGING_BODY:-'TRUE'}
 export NO_LOGGING_RESPONSE=${NO_LOGGING_RESPONSE:-'TRUE'}
 export STATSD_METRICS_ENABLED=${STATSD_METRICS:-'TRUE'}
 export STATSD_SERVER=${STATSD_SERVER:-'127.0.0.1'}
+export AWS_REGION=${AWS_REGION:-'eu-west-1'}
 
 export HTTPS_REDIRECT_PORT_STRING=":${HTTPS_REDIRECT_PORT}"
 if [ "${HTTPS_REDIRECT_PORT_STRING}" == ":" ]; then
@@ -37,13 +38,13 @@ function download() {
     error=0
 
     for i in {1..5}; do
+
         if [ ${i} -gt 1 ]; then
             msg "About to retry download for ${file_url}..."
             sleep 1
         fi
         if [ "${DOWNLOAD_VIA_S3_VPC_ENDPOINT}" == "TRUE" ]; then
-            REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
-            aws s3 cp --region "${REGION}" --endpoint-url https://s3-"${REGION}".amazonaws.com "${NAXSI_RULES_URL_CSV}" ${file_path}
+            aws s3 cp --region "${AWS_REGION}" --endpoint-url https://s3-"${AWS_REGION}".amazonaws.com "${NAXSI_RULES_URL_CSV}" ${file_path}
             error=$?
         elif curl --max-time 30 --fail -s -o ${file_path} ${file_url} ; then
             error=0

--- a/go.sh
+++ b/go.sh
@@ -211,5 +211,4 @@ if [ "${STATSD_METRICS_ENABLED}" = "TRUE" ]; then
     echo "statsd_count \"waf.status.\$status\" 1;" > ${NGIX_CONF_DIR}/nginx_statsd_metrics.conf
 fi
 
-
 eval "${NGINX_BIN} -g \"daemon off;\""


### PR DESCRIPTION
##WHAT

Stops the container attempting to determine the region by making a call to the EC2 metadata service.

Requests to this endpoint will be blocked to ensure role based access on ECS based deployments where secrets management best practice is dependent on restricting access to the parameter store based on assigned roles. Services being able to access the EC2 metadata service are able to bypass this security restriction so this is blocked via iptables modifications on an ECS cluster host instance.

As such, the container is dependent on "AWS_REGION" as an environment variable, being passed to it.