### PR TITLE
PP-2600 check nginx status module is working

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -67,6 +67,7 @@ if [ ! -z "${DISABLE_SYSDIG_METRICS}" ]; then
         stub_status on;
         access_log   off;
         allow 127.0.0.1;
+        allow 172.17.0.1;
         deny all;
       }
     }


### PR DESCRIPTION
## WHAT
Modifies the configuration of NGINX to allow nginx_status endpoint requests to also accept connections from the docker bridge networking interface.

## HOW
A block of code in the go.sh file, enables the nginx_status endpoint in the event that a DISABLE_SYSDIG_METRICS environment variable is set with anything other than an empty string. This inserts a configuration block into the main NGINX configuration file drops any connection requests from anything other than 127.0.0.1

This PR adds the following configuration to the code block: 

`allow 172.17.0.1;`
