### PR TITLE
PP-4168 Allow keepalive connections to upstream

### DIFF
--- a/enable_location.sh
+++ b/enable_location.sh
@@ -170,9 +170,9 @@ done
 
 if [ "${ENABLE_WEB_SOCKETS}" == "TRUE" ]; then
     msg "Enable web socket support"
-    WEB_SOCKETS="include ${NGIX_CONF_DIR}/nginx_web_sockets_proxy.conf;"
+    CONNECTION_CONFIG="include ${NGIX_CONF_DIR}/nginx_web_sockets_proxy.conf;"
 else
-    unset WEB_SOCKETS
+    CONNECTION_CONFIG="include ${NGIX_CONF_DIR}/nginx_keep_alive.conf;"
 fi
 if [ "${ADD_NGINX_LOCATION_CFG}" != "" ]; then
     msg "Enabling extra ADD_NGINX_LOCATION_CFG:${ADD_NGINX_LOCATION_CFG}"
@@ -219,7 +219,7 @@ location ${LOCATION} {
 
     include  ${NAXSI_LOCATION_RULES}/*.rules ;
 
-    ${WEB_SOCKETS}
+    ${CONNECTION_CONFIG}
     $(cat /location_template.conf)
     ${SSL_CERTIFICATE}
     ${SSL_VERIFY}

--- a/location_template.conf
+++ b/location_template.conf
@@ -13,5 +13,3 @@
     proxy_intercept_errors on;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_http_version 1.1;
-    proxy_set_header Connection "";

--- a/location_template.conf
+++ b/location_template.conf
@@ -13,3 +13,5 @@
     proxy_intercept_errors on;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";

--- a/nginx_keep_alive.conf
+++ b/nginx_keep_alive.conf
@@ -1,0 +1,2 @@
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";


### PR DESCRIPTION
We are seeing a large number of connections to the app behind nginx, which
we believe is caused by nginx not keeping connections alive.

This commit adds config to do keepalives
as per http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive