### PR TITLE
PP-5070: Generate a selfsigned TLS cert if necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,12 @@ MAINTAINER Lewis Marshall <lewis@technoplusit.co.uk>
 
 WORKDIR /root
 
-RUN yum -y update && yum -y upgrade && yum clean all
+RUN yum -y install deltarpm && yum -y update && yum -y upgrade && yum clean all && yum -y erase deltarpm
 
 ADD ./build.sh /root/
 RUN ./build.sh
 
-RUN yum install -y openssl && \
-    yum clean all && \
-    mkdir -p /etc/keys && \
-    cd /etc/keys && \
-    openssl req -x509 -newkey rsa:2048 -keyout key -out crt -days 360 -nodes -subj '/CN=test'
+RUN yum install -y openssl && yum clean all
 
 # This takes a while so best to do it during build
 RUN openssl dhparam -out /usr/local/openresty/nginx/conf/dhparam.pem 2048
@@ -55,6 +51,7 @@ RUN useradd nginx && \
     mkdir /usr/local/openresty/nginx/fastcgi_temp && \
     mkdir /usr/local/openresty/nginx/uwsgi_temp && \
     mkdir /usr/local/openresty/nginx/scgi_temp && \
+    mkdir /etc/keys && \
     chown -R nginx:nginx /usr/local/openresty/naxsi/locations && \
     chown -R nginx:nginx /usr/local/openresty/nginx/conf && \
     chown -R nginx:nginx /usr/local/openresty/nginx/logs && \
@@ -63,7 +60,8 @@ RUN useradd nginx && \
     chown -R nginx:nginx /usr/local/openresty/nginx/fastcgi_temp && \
     chown -R nginx:nginx /usr/local/openresty/nginx/uwsgi_temp && \
     chown -R nginx:nginx /usr/local/openresty/nginx/scgi_temp && \
-    chown -R nginx:nginx /usr/share/GeoIP
+    chown -R nginx:nginx /usr/share/GeoIP && \
+    chown -R nginx:nginx /etc/keys
 
 WORKDIR /usr/local/openresty
 

--- a/go.sh
+++ b/go.sh
@@ -6,6 +6,15 @@ export LOG_UUID=FALSE
 
 . /defaults.sh
 
+# Generate a selfsigned key and certificate if we don't have one
+if [ ! -f /etc/keys/crt ]; then
+  dir=`mktemp -d`
+  openssl req -x509 -days 1000 -newkey rsa:2048 -nodes -subj '/CN=waf' -keyout "$dir/key" -out "$dir/crt"
+  install -m 0600 -o nginx -g nginx "$dir/key" /etc/keys/key
+  install -m 0644 -o nginx -g nginx "$dir/crt" /etc/keys/crt
+  rm -rf "$dir"
+fi
+
 cat > ${NGIX_CONF_DIR}/server_certs.conf <<-EOF_CERT_CONF
     ssl_certificate     ${SERVER_CERT};
     ssl_certificate_key ${SERVER_KEY};


### PR DESCRIPTION
If we don't have a TLS key and certificate mounted into the container by
Docker, generate a selfsigned one ourselves.