### PR TITLE
Make the error log level configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # quay.io/ukhomeofficedigital/centos-base:latest
-FROM quay.io/ukhomeofficedigital/centos-base@sha256:12bd649a54434999a2d9d33767a56b2e018db99170f2c4c10dee9a552123ce44
+FROM quay.io/ukhomeofficedigital/centos-base@sha256:784951d9caa3459a017806bf65c42d49655038f4aeb91f5eccdfd18f198b166e
 MAINTAINER Lewis Marshall <lewis@technoplusit.co.uk>
 
 WORKDIR /root

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This is useful when testing or for development instances or when a load-balancer
 * `STATSD_METRICS_ENABLED` - Toggle if metrics are logged to statsd (defaults to true)
 * `STATSD_SERVER` - Server to send statsd metrics to, defaults to 127.0.0.1
 * `DISABLE_SYSDIG_METRICS` - Set to any non-empty string to disable support for Sysdig's metric collection
+* `ERROR_LOG_LEVEL` - The log level to use for nginx's `error_log` directive (default: 'error')
 
 ### Ports
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -576,7 +576,7 @@ start_test "Test setting empty UUID name defaults correctly..." "${STD_CMD} \
            -e \"ENABLE_UUID_PARAM=HEADER\" \
            --link \"${MOCKSERVER}:${MOCKSERVER}\" "
 curl -sk https://${DOCKER_HOST_NAME}:${PORT}
-docker logs "${MOCKSERVER}" 2>/dev/null | grep "nginxId"
+docker logs "${MOCKSERVER}" 2>/dev/null | grep -i "nginxId"
 echo "Testing UUID_VAR_NAME default if empty works"
 
 echo "_________________________________"

--- a/go.sh
+++ b/go.sh
@@ -135,6 +135,10 @@ else
     msg "No client certs mounted - not loading..."
 fi
 
+cat >> ${NGIX_CONF_DIR}/error_logging.conf <<-EOF_ERRORLOGGING
+error_log /dev/stderr ${ERROR_LOG_LEVEL:-error};
+EOF_ERRORLOGGING
+
 case "${LOG_FORMAT_NAME}" in
     json|text|custom)
         msg "Logging set to ${LOG_FORMAT_NAME}"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,4 @@
-error_log /dev/stderr error;
+include /usr/local/openresty/nginx/conf/error_logging.conf;
 
 env LOG_UUID;
 env UUID_VAR_NAME;


### PR DESCRIPTION
Allow the default level of error logging ('error') to be overridden via an
environment variable, 'ERROR_LOG_LEVEL'.