### PR TITLE
Adds support for optional Nginx "delay" rate limiting argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Variables to control how to configure the proxy (can be set per location, see
  for easy tracking in down stream logs e.g. `X-Request-Id: 50c91049-667f-4286-c2f0-86b04b27d3f0`.
 * `REQS_PER_MIN_PER_IP` - Will limit requests based on IP e.g. set to 60 to allow one request per second.
 * `REQS_PER_PAGE` - Will limit requests to 'bursts' of x requests at a time before terminating (will default to 20)
+* `RATE_LIMIT_DELAY` - The number of requests to process without delay within the burst setting e.g. `delay=10` (default off, can also be set to `nodelay`)
 
 #### Single set Variables
 

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -20,7 +20,7 @@ NAXSI_USE_DEFAULT_RULES=$(get_id_var ${LOCATION_ID} NAXSI_USE_DEFAULT_RULES)
 ENABLE_UUID_PARAM=$(get_id_var ${LOCATION_ID} ENABLE_UUID_PARAM)
 REQS_PER_MIN_PER_IP=$(get_id_var ${LOCATION_ID} REQS_PER_MIN_PER_IP)
 REQS_PER_PAGE=$(get_id_var ${LOCATION_ID} REQS_PER_PAGE)
-DELAY_PER_PAGE=$(get_id_var ${LOCATION_ID} DELAY_PER_PAGE)
+RATE_LIMIT_DELAY=$(get_id_var ${LOCATION_ID} RATE_LIMIT_DELAY)
 
 msg "Setting up location '${LOCATION}' to be proxied to " \
     "${PROXY_SERVICE_HOST}:${PROXY_SERVICE_PORT}${LOCATION}"
@@ -73,27 +73,18 @@ fi
 
 if [ "${REQS_PER_MIN_PER_IP}" != "" ]; then
     REQS_PER_PAGE=${REQS_PER_PAGE:-20}
-    DELAY_PER_PAGE=${DELAY_PER_PAGE:-""}
+    RATE_LIMIT_DELAY=${RATE_LIMIT_DELAY:-""}
     msg "Enabling REQS_PER_MIN_PER_IP:${REQS_PER_MIN_PER_IP}"
     msg "Enabling REQS_PER_PAGE:${REQS_PER_PAGE}"
-    msg "Enabling DELAY_PER_PAGE:${DELAY_PER_PAGE}"
+    msg "Enabling RATE_LIMIT_DELAY:${RATE_LIMIT_DELAY}"
     if [ "${REQS_PER_PAGE}" != "0" ]; then
       burst_setting="burst=${REQS_PER_PAGE}"
     else
       unset burst_setting
     fi
-    if [ "${DELAY_PER_PAGE}" != "" ]; then
-      if [ "${DELAY_PER_PAGE}" == "nodelay" ]; then
-        delay_setting="nodelay"
-      else
-        delay_setting="delay=${DELAY_PER_PAGE}"
-      fi
-    else
-      unset delay_setting
-    fi
     echo "limit_req_zone \$binary_remote_addr zone=reqsbuffer${LOCATION_ID}:10m rate=${REQS_PER_MIN_PER_IP}r/m;" \
         >${NGIX_CONF_DIR}/nginx_rate_limits_${LOCATION_ID}.conf
-    REQ_LIMITS="limit_req zone=reqsbuffer${LOCATION_ID} ${burst_setting} ${delay_setting};"
+    REQ_LIMITS="limit_req zone=reqsbuffer${LOCATION_ID} ${burst_setting} ${RATE_LIMIT_DELAY};"
 fi
 
 # Now create the location specific include file.

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -20,6 +20,7 @@ NAXSI_USE_DEFAULT_RULES=$(get_id_var ${LOCATION_ID} NAXSI_USE_DEFAULT_RULES)
 ENABLE_UUID_PARAM=$(get_id_var ${LOCATION_ID} ENABLE_UUID_PARAM)
 REQS_PER_MIN_PER_IP=$(get_id_var ${LOCATION_ID} REQS_PER_MIN_PER_IP)
 REQS_PER_PAGE=$(get_id_var ${LOCATION_ID} REQS_PER_PAGE)
+DELAY_PER_PAGE=$(get_id_var ${LOCATION_ID} DELAY_PER_PAGE)
 
 msg "Setting up location '${LOCATION}' to be proxied to " \
     "${PROXY_SERVICE_HOST}:${PROXY_SERVICE_PORT}${LOCATION}"
@@ -72,16 +73,27 @@ fi
 
 if [ "${REQS_PER_MIN_PER_IP}" != "" ]; then
     REQS_PER_PAGE=${REQS_PER_PAGE:-20}
+    DELAY_PER_PAGE=${DELAY_PER_PAGE:-""}
     msg "Enabling REQS_PER_MIN_PER_IP:${REQS_PER_MIN_PER_IP}"
     msg "Enabling REQS_PER_PAGE:${REQS_PER_PAGE}"
+    msg "Enabling DELAY_PER_PAGE:${DELAY_PER_PAGE}"
     if [ "${REQS_PER_PAGE}" != "0" ]; then
       burst_setting="burst=${REQS_PER_PAGE}"
     else
       unset burst_setting
     fi
+    if [ "${DELAY_PER_PAGE}" != "" ]; then
+      if [ "${DELAY_PER_PAGE}" == "nodelay" ]; then
+        delay_setting="nodelay"
+      else
+        delay_setting="delay=${DELAY_PER_PAGE}"
+      fi
+    else
+      unset delay_setting
+    fi
     echo "limit_req_zone \$binary_remote_addr zone=reqsbuffer${LOCATION_ID}:10m rate=${REQS_PER_MIN_PER_IP}r/m;" \
         >${NGIX_CONF_DIR}/nginx_rate_limits_${LOCATION_ID}.conf
-    REQ_LIMITS="limit_req zone=reqsbuffer${LOCATION_ID} ${burst_setting};"
+    REQ_LIMITS="limit_req zone=reqsbuffer${LOCATION_ID} ${burst_setting} ${delay_setting};"
 fi
 
 # Now create the location specific include file.


### PR DESCRIPTION
This allows the number of requests (specified in the delay param) to be processed without delay. This defines the point at which, within the burst size, excessive requests are throttled to comply with the define rate limit.

See: https://www.nginx.com/blog/rate-limiting-nginx/