### PR TITLE
Configure forwarded for ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ location.
 * `HTTP_LISTEN_PORT` - Change the default inside the container from 10080.
 * `HTTPS_LISTEN_PORT` - Change the default inside the container from 10443.
 * `ERROR_LOG_LEVEL` - The log level to use for nginx's `error_log` directive (default: 'error')
+* `REAL_IP_HEADER` - The header containing the forwarded client ip e.g. `X-Forwarded-For`
+* `REAL_IP_FROM` - The IP or CIDR from which to trust IPs set in REAL_IP_HEADER
 
 ### Ports
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -4,7 +4,7 @@ export NGIX_CONF_DIR=/etc/nginx/conf
 export HTTP_LISTEN_PORT=${HTTP_LISTEN_PORT:-10080}
 export HTTPS_LISTEN_PORT=${HTTPS_LISTEN_PORT:-10443}
 export AWS_REGION=${AWS_REGION:-'eu-west-1'}
-export CUSTOM_LOG_FORMAT=${CUSTOM_LOG_FORMAT:=\''$real_client_ip_if_set$remote_addr - $remote_user [$time_local] "$_request" X-Request-Id=$request_id $status $bytes_sent "$_http_referer" "$http_user_agent" "$gzip_ratio" '\'}
+export CUSTOM_LOG_FORMAT=${CUSTOM_LOG_FORMAT:=\''$remote_addr - $remote_user [$time_local] "$_request" X-Request-Id=$request_id $status $bytes_sent "$_http_referer" "$http_user_agent" "$gzip_ratio" '\'}
 
 function download() {
 

--- a/go.sh
+++ b/go.sh
@@ -42,14 +42,14 @@ cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 	listen ${HTTPS_LISTEN_PORT} ssl;
 EOF-LISTEN
 
-
-NGIX_REAL_IP_CONF="${NGINX_CONF_DIR}/nginx_real_ip.conf"
 if [ -n "${REAL_IP_HEADER:-}" && -n "${REAL_IP_FROM:-}" ]; then
-    cat > ${NGIX_REAL_IP_CONF} <<-EOF-REALIP
-        set_real_ip_from '${REAL_IP_FROM}';
-        real_ip_header '${REAL_IP_HEADER}';
-        real_ip_recursive on;
-    EOF-REALIP
+    NGIX_REAL_IP_CONF="${NGINX_CONF_DIR}/nginx_server_extras_real_ip.conf"
+    touch ${NGINX_REAL_IP_CONF}
+cat > ${NGIX_REAL_IP_CONF} <<-EOF-REALIP
+    set_real_ip_from '${REAL_IP_FROM}';
+    real_ip_header '${REAL_IP_HEADER}';
+    real_ip_recursive on;
+EOF-REALIP
 fi
 
 

--- a/go.sh
+++ b/go.sh
@@ -42,6 +42,17 @@ cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 	listen ${HTTPS_LISTEN_PORT} ssl;
 EOF-LISTEN
 
+
+NGIX_REAL_IP_CONF="${NGINX_CONF_DIR}/nginx_real_ip.conf"
+if [ -n "${REAL_IP_HEADER:-}" && -n "${REAL_IP_FROM:-}" ]; then
+    cat > ${NGIX_REAL_IP_CONF} <<-EOF-REALIP
+        set_real_ip_from '${REAL_IP_FROM}';
+        real_ip_header '${REAL_IP_HEADER}';
+        real_ip_recursive on;
+    EOF-REALIP
+fi
+
+
 IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"
 for i in "${!LOCATIONS_ARRAY[@]}"; do
     /enable_location.sh $((${i} + 1)) ${LOCATIONS_ARRAY[$i]}

--- a/go.sh
+++ b/go.sh
@@ -40,7 +40,6 @@ cat > ${NGIX_LISTEN_CONF} <<-EOF-LISTEN
 	listen localhost:10418 ssl;
 	listen ${HTTP_LISTEN_PORT};
 	listen ${HTTPS_LISTEN_PORT} ssl;
-	set \$real_client_ip_if_set '';
 EOF-LISTEN
 
 IFS=',' read -a LOCATIONS_ARRAY <<< "$LOCATIONS_CSV"


### PR DESCRIPTION
This correctly sets the real ip of the request to that of the client when nginx is forwarded the request from a load balancer using the header specified by `real_ip_header`. 

This ensures features such as IP rate limiting operate on the client's IP address, not the load balancer's IP. `set_real_ip_from` ensures only trusted IPs (e.g. VPC cidr range) are able to specify the forwarded IP.

Corresponding config PR: https://github.com/alphagov/pay-infra/pull/2379