### PR TITLE
PP-6483 Allow configurable body buffer size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl"]
 # naxsi and awscli are not available from the main Alpine repositories yet.
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing", "add", \
-     "nginx-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-xslt-filter=1.16.0-r1", "aws-cli"]
+     "nginx-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-xslt-filter=1.16.0-r1"]
+
+RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/community", "add", "aws-cli"]
 
 RUN ["install", "-d", "/etc/nginx/ssl"]
 RUN ["openssl", "dhparam", "-out", "/etc/nginx/ssl/dhparam.pem", "2048"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Note the following variables can only be set once:
 [Using Multiple Locations](#using-multiple-locations). Note, if this isn't set, `/` will be used as the default
 location.
 * `CLIENT_MAX_BODY_SIZE` - Can set a larger upload than Nginx defaults in MB.
+* `CLIENT_BODY_BUFFER_SIZE` - Can set a larger body buffer size than Nginx defaults in MB.
 * `HTTP_LISTEN_PORT` - Change the default inside the container from 10080.
 * `HTTPS_LISTEN_PORT` - Change the default inside the container from 10443.
 * `ERROR_LOG_LEVEL` - The log level to use for nginx's `error_log` directive (default: 'error')

--- a/go.sh
+++ b/go.sh
@@ -70,6 +70,12 @@ if [ -n "${CLIENT_MAX_BODY_SIZE:-}" ]; then
     msg "Setting '${UPLOAD_SETTING};'"
 fi
 
+if [ -n "${CLIENT_BODY_BUFFER_SIZE:-}" ]; then
+    UPLOAD_SETTING="client_body_buffer_size ${CLIENT_BODY_BUFFER_SIZE}m;"
+    echo "${UPLOAD_SETTING}">>/etc/nginx/conf/upload_size.conf
+    msg "Setting '${UPLOAD_SETTING};'"
+fi
+
 cat > /etc/nginx/conf/error_logging.conf <<-EOF_ERRORLOGGING
 error_log /dev/stderr ${ERROR_LOG_LEVEL:-error};
 EOF_ERRORLOGGING


### PR DESCRIPTION
Some ECS apps may want to specify a higher `CLIENT_BODY_BUFFER_SIZE`,
allow them to do this through environment variables.