### PR TITLE
PP-6483 Update alpine linux to 3.11.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998
+FROM alpine@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
 
 USER root
 


### PR DESCRIPTION
Upgrade alpine linux to 3.11.6. Our current pinned version is not
compatible with the community package (latest version) for aws-cli. This
is now needed as the package has been removed from `testing/edge`.

Relates to https://github.com/alphagov/pay-nginx-proxy/pull/35

With @rjbaker