### PR TITLE
PP-7495 Replace bbc.co.uk in the tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,66 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2021-01-22T09:18:01Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -113,28 +113,28 @@ curl -s -I -X GET -k --compressed https://${DOCKER_HOST_NAME}:${PORT}/gzip | gre
 
 start_test "Start with multi locations settings" "${STD_CMD} \
            --log-driver json-file \
-           -e \"LOCATIONS_CSV=/,/news\" \
+           -e \"LOCATIONS_CSV=/,/using-govuk-pay\" \
            -e \"PROXY_SERVICE_HOST_1=http://www.w3.org\" \
            -e \"PROXY_SERVICE_PORT_1=80\" \
-           -e \"PROXY_SERVICE_HOST_2=http://www.bbc.co.uk\" \
-           -e \"PROXY_SERVICE_PORT_2=80\""
+           -e \"PROXY_SERVICE_HOST_2=https://www.payments.service.gov.uk\" \
+           -e \"PROXY_SERVICE_PORT_2=443\""
 
 
 echo "Test for location 1 @ /..."
 curl --fail -sk -o /dev/null https://${DOCKER_HOST_NAME}:${PORT}/
-echo "Test for news..."
-curl --fail -sk -o /dev/null -H "Host: www.bbc.co.uk" https://${DOCKER_HOST_NAME}:${PORT}/news
+echo "Test for payment page..."
+curl --fail -sk -o /dev/null -H "Host: www.payments.service.gov.uk" https://${DOCKER_HOST_NAME}:${PORT}/using-govuk-pay
 
 start_test "Start with Multiple locations, single proxy and NAXSI download." "${STD_CMD} \
            --log-driver json-file \
-           -e \"PROXY_SERVICE_HOST=http://www.bbc.co.uk\" \
-           -e \"PROXY_SERVICE_PORT=80\" \
-           -e \"LOCATIONS_CSV=/,/news\" \
+           -e \"PROXY_SERVICE_HOST=https://www.payments.service.gov.uk\" \
+           -e \"PROXY_SERVICE_PORT=443\" \
+           -e \"LOCATIONS_CSV=/,/using-govuk-pay\" \
            -e \"NAXSI_RULES_URL_CSV_1=https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules\" \
            -e \"NAXSI_RULES_MD5_CSV_1=3b3c24ed61683ab33d8441857c315432\""
 
 echo "Test for all OK..."
-curl --fail -sk -o /dev/null -H "Host: www.bbc.co.uk" https://${DOCKER_HOST_NAME}:${PORT}/
+curl --fail -sk -o /dev/null -H "Host: www.payments.service.gov.uk" https://${DOCKER_HOST_NAME}:${PORT}/
 
 start_test "Start with Custom upload size" "${STD_CMD} \
            --log-driver json-file \


### PR DESCRIPTION
    PP-7495 Replace bbc.co.uk in the tests

    The ci tests have begun failing trying to proxy on to www.bbc.co.uk
    returning a 421:Misdirected Request. Replace bbc.co.uk with our own
    payment page www.payments.service.gov.uk.

    The version of nginx has not changed and the tests were failing on the
    main branch so we suspect this is down to a change on server(s) hosting
    www.bbc.co.uk. We have created a story to investigate which captures our
    intial thoughts https://payments-platform.atlassian.net/browse/PP-7679

    with @dj-maisy


with @dj-maisy

## WHAT ##
We don't understand why it has started failing for the BBC and have created this story to investigate further https://payments-platform.atlassian.net/browse/PP-7679
