### PR TITLE
PP-7683 - Add alpha release tag to repo after successful Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,5 +37,13 @@ pipeline {
         }
       }
     }
+    stage('Tag Build') {
+      when {
+        branch 'master'
+      }
+      steps {
+        tagDeployment("docker-nginx-proxy")
+      }
+    }
   }
 }


### PR DESCRIPTION
Description:
- As part of PP-7683 we are having Concourse pull from Dockerhub and pushing the images to ECR test. However for our current apps Concourse
 listens for a new alpha-release tag on our Git repos to indicate that the corresponding Docker image has been pushed to Dockerhub. If we were
 to listen simply on a new image in Dockerhub then we would have no way of extracting the Git commit SHA as there is no guarantee that the commit SHA
 for the latest master corresponding to that image (e.g. whilst the image is being built a new master merge occurs). To solve this issue we add a step
 in the Jenkins pipeline to tag the nginx-proxy repo so when a new alpha-release-* tag occurs we know that the corresponding Docker image has been pushed into Dockerhub.