### PR TITLE
PP-7683 - Update service name to match git tag script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        tagDeployment("docker-nginx-proxy")
+        tagDeployment("nginx-proxy")
       }
     }
   }


### PR DESCRIPTION
Description:
- The tag_and_capture_notes_commit_based.sh script passes in the $SERVICE_TO_TAG into git clone --bare "git@github.com:alphagov/pay-${SERVICE_TO_TAG}.git". But we are currently
 passing in docker-nginx-proxy whilst the Git repo URL is pay-nginx-proxy. This PR fixes this error