### PR TITLE
BAU - Update nginx naxsi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl"]
 # naxsi and awscli are not available from the main Alpine repositories yet.
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing", "add", \
-     "nginx-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-naxsi=1.16.0-r1", "nginx-naxsi-mod-http-xslt-filter=1.16.0-r1"]
+     "nginx-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-xslt-filter=1.16.1-r0"]
 
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/community", "add", "aws-cli"]
 


### PR DESCRIPTION
Description:
- Linux alpine package manager automatically drops older versions when a newer version is released. Since
1.16.1-r0 is released that means our current version of 1.16.0.r1 is dropped
- This PR fixes this and ensures our docker image can now be built