### PR TITLE
PP-7870 Pin aws-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl"]
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing", "add", \
      "nginx-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-xslt-filter=1.16.1-r0"]
 
-RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/community", "add", "aws-cli"]
+RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/community", "add", "aws-cli=1.18.177-r0"]
 
 RUN ["install", "-d", "/etc/nginx/ssl"]
 RUN ["openssl", "dhparam", "-out", "/etc/nginx/ssl/dhparam.pem", "2048"]


### PR DESCRIPTION
Previous to this change the latest version of the aws-cli was installed
from the edge repo. On the 5 April 2021 the latest version was rebuilt
against python 3.9. The Alpine base image that we use includes Python
3.8.8. The start up script for the latest aws-cli package places the
  necessary python packages under
  `/usr/lib/python3.9/site-packages/awscli` and the default Python path
  being used in the Alpine base image does not include any python3.9
  directories so it fails to start.

  We'll want to upgrade our Alpine base image and subsequently the other
  packages but for now this change pins the version of the aws-cli to
  the last know version that works with our Alpine base image:
  https://pkgs.alpinelinux.org/package/v3.13/community/x86_64/aws-cli
  
  ## WHAT ##
I noticed this whilst rebuilding nginx-proxy to adjust some settings in the test-perf-1 environment.
Confirmation of the current version of `aws-cli` installed in our environments:
```
danworth@test-12-www-ecs-i-0ff560dcd60ad3909:~$ sudo docker exec -it 4f5668dbb884 bash
bash-5.0# apk info aws-cli
aws-cli-1.18.177-r0 description:
Universal Command Line Interface for Amazon Web Services
```

This is what happens when attempting to run the [latest edge version](https://git.alpinelinux.org/aports/commit/?id=6eca884473f2410aa51aaafcfcbc09efddaea83b) of aws-cli
```
bash-5.0# aws
Traceback (most recent call last):
  File "/usr/bin/aws", line 19, in <module>
    import awscli.clidriver
ModuleNotFoundError: No module named 'awscli'
```

## TESTING
This has been deployed into test-perf-1 for frontend and connector and both start; previously Frontend was failing to start with the latest edge version of the `aws-cli` package. I have run a perf test with 20tx/second which passed.

https://build.ci.pymnt.uk/job/run-performance-test/108/console