### PR TITLE
PP-8500 Bump naxsi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl"]
 # naxsi and awscli are not available from the main Alpine repositories yet.
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing", "add", \
-     "nginx-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-naxsi=1.16.1-r0", "nginx-naxsi-mod-http-xslt-filter=1.16.1-r0"]
+     "nginx-naxsi=1.16.1-r1", "nginx-naxsi-mod-http-naxsi=1.16.1-r1", "nginx-naxsi-mod-http-xslt-filter=1.16.1-r1"]
 
 RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/community", "add", "aws-cli=1.18.177-r0"]
 


### PR DESCRIPTION
The `r0` release of naxsi is no longer availble from the edge repo and
the image will not build. `r1` seems to be next availble version.