### PR TITLE
[PP-8910] Bump Alpine to 3.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.14.1@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+FROM alpine:3.14.3@sha256:5e604d3358ab7b6b734402ce2e19ddd822a354dc14843f34d36c603521dbb4f9
 
 USER root
 
 ENTRYPOINT ["tini", "--"]
 
 RUN ["apk", "--no-cache", "upgrade"]
-RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl", "python3", "py-pip", "nginx-mod-http-naxsi=1.20.1-r3", "nginx-mod-http-xslt-filter=1.20.1-r3"]
+RUN ["apk", "--no-cache", "add", "tini", "dnsmasq", "bash", "curl", "openssl", "python3", "py-pip", "nginx-mod-http-naxsi=1.20.2-r0", "nginx-mod-http-xslt-filter=1.20.2-r0"]
 
 RUN ["pip", "install", "awscli~=1.20.0"]
 


### PR DESCRIPTION
## What?
This bumps Alpine to 3.14.3 from 3.14.1 and updates the associated Nginx packages.

## Why?
Updating through 3.14.2 addresses the following OpenSSL vulnerabilities:

- CVE-2021-3711
- CVE-2021-3712

The update to 3.14.3 also addresses the following vulnerabilities:

- CVE-2020-25125 (for GnuPG)
- CVE-2021-22945 (for cURL)
- CVE-2021-22946 (for cURL)
- CVE-2021-22947 (for cURL)

As well as numerous security fixes for busybox.

## How?
You can test build the new Dockerfile:
```sh
git checkout PP-8910_update_alpine_314
docker build -t govukpay/docker-nginx-proxy .
```

You can _even_ run it in test by deploying `govukpay/docker-nginx-proxy:3.14.3-test` as a sidecar for the app of your choice.