### PR TITLE
PP-7788: Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-
-services:
-  - docker
-
-script:
-  - travis_retry ./ci-build.sh


### PR DESCRIPTION
## WHAT
We are deprecating use of Travis CI.

## HOW 
CI doesn't rely on travis CI anymore
