### PR TITLE
BAU: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - docker


### PR DESCRIPTION
Adds dependabot config for the alpine docker image. I think this repo previously had the older version of Dependabot running against it, and never got switched to the newer native version.

I've created the labels in the repo settings.