### PR TITLE
BAU: Exclude Github Actions/Dependabot from post-merge worklow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
See ADR https://github.com/alphagov/pay-architecture/pull/49/files