### PR TITLE
BAU: Bump nginx alpine packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN ["apk", "--no-cache", "add", \
   "curl", \
   "dnsmasq", \
   # If you update these nginx packages you MUST update the software components list: https://pay-team-manual.cloudapps.digital/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.20.2-r0", \
-  "nginx-mod-http-xslt-filter=1.20.2-r0", \
+  "nginx-mod-http-naxsi=1.20.2-r1", \
+  "nginx-mod-http-xslt-filter=1.20.2-r1", \
   "openssl", \
   "py-pip", \
   "python3", \


### PR DESCRIPTION
The previous versions have been removed from the APK registry, so the image build is failing.

https://alpine.pkgs.org/3.15/alpine-main-x86_64/nginx-mod-http-naxsi-1.20.2-r1.apk.html

No changes to the actual code as far as I can see, just a new release.