### PR TITLE
ZD#4989490 Increase buffer size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN ["apk", "--no-cache", "add", \
   "curl", \
   "dnsmasq", \
   # If you update these nginx packages you MUST update the software components list: https://pay-team-manual.cloudapps.digital/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.20.2-r2", \
-  "nginx-mod-http-xslt-filter=1.20.2-r2", \
+  "nginx-mod-http-naxsi=1.22.0-r0", \
+  "nginx-mod-http-xslt-filter=1.22.0-r0", \
   "openssl", \
   "py-pip", \
   "python3", \

--- a/go.sh
+++ b/go.sh
@@ -79,7 +79,7 @@ fi
 if [ -n "${ENABLE_BIG_BUFFERS:-}" ]; then
 cat > /etc/nginx/conf/nginx_big_buffers.conf <<-EOF_BIGBUFFERS
     # Proxy Buffer Size Increase
-    proxy_buffer_size 8k;
+    proxy_buffer_size 12k;
 EOF_BIGBUFFERS
 fi
 


### PR DESCRIPTION
## WHAT
- Increases proxy buffer size to 12k to allow services enter and view long text on ‘manage payment links’ pages in selfservice
- Bumps nginx modules to new versions