### PR TITLE
BAU Bump Nginx NAXSI packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN ["apk", "--no-cache", "add", \
   "curl", \
   "dnsmasq", \
   # If you update these nginx packages you MUST update the software components list: https://pay-team-manual.cloudapps.digital/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.22.0-r1", \
-  "nginx-mod-http-xslt-filter=1.22.0-r1", \
+  "nginx-mod-http-naxsi=1.22.1-r0", \
+  "nginx-mod-http-xslt-filter=1.22.1-r0", \
   "openssl", \
   "py-pip", \
   "python3", \


### PR DESCRIPTION
Brings in security fixes for CVE-2022-41741 and CVE-2022-41742. See [http://nginx.org/en/CHANGES](http://nginx.org/en/CHANGES).

Team manual will be updated separately (along with the changes from https://github.com/alphagov/pay-nginx-forward-proxy/pull/50)