### PR TITLE
BAU: Add Dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       - dependencies
       - govuk-pay
       - docker
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - github_actions


### PR DESCRIPTION
Configure Dependabot updates for its Github Actions dependencies.