### PR TITLE
PP-12015: Add GHA to check docker sources are manifests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -144,3 +144,6 @@ jobs:
       - name: Shutdown Docker Compose Stack (Local Only)
         if: ${{ env.ACT }}
         run: docker-compose down
+
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master


### PR DESCRIPTION
WHAT
Use the reusable workflow in pay-ci to ensure all FROM lines in the Dockerfile are pointing to manifest files