### PR TITLE
PP-12308: Bump release package version of nginx modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN ["apk", "--no-cache", "add", \
   "bash", \
   "curl", \
   "dnsmasq", \
-  # If you update these nginx packages you MUST update the software components list: https://pay-team-manual.cloudapps.digital/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.24.0-r14", \
-  "nginx-mod-http-xslt-filter=1.24.0-r14", \
+  # If you update these nginx packages you MUST update the software components list: https://manual.payments.service.gov.uk/manual/policies-and-procedures/software-components-list.html
+  "nginx-mod-http-naxsi=1.24.0-r15", \
+  "nginx-mod-http-xslt-filter=1.24.0-r15", \
   "openssl", \
   "tini" \
 ]


### PR DESCRIPTION
Bump nginx module releases, the current ones don't build anymore. Also fix the link to the team manual