### PR TITLE
PP-12694: Bump nginx modules and pin alpine to 3.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    ignore:
+      - dependency-name: "alpine"
+        versions:
+          - "> 3.19"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN ["apk", "--no-cache", "add", \
   "curl", \
   "dnsmasq", \
   # If you update these nginx packages you MUST update the software components list: https://manual.payments.service.gov.uk/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.24.0-r15", \
-  "nginx-mod-http-xslt-filter=1.24.0-r15", \
+  "nginx-mod-http-naxsi=1.24.0-r16", \
+  "nginx-mod-http-xslt-filter=1.24.0-r16", \
   "openssl", \
   "tini" \
 ]


### PR DESCRIPTION
- Pins alpine base image to 3.19. We cannot bump to alpine 3.20 as there are incompatibilities with the aws-cli package. The aws-cli package maintainers recommend pinning to alpine 3.19 https://github.com/aws/aws-cli/issues/8342
- Bumps the naxsi packages manually in order to pick up the latest updates