### PR TITLE
PP-11913: Update naxsi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN ["apk", "--no-cache", "add", \
   "curl", \
   "dnsmasq", \
   # If you update these nginx packages you MUST update the software components list: https://manual.payments.service.gov.uk/manual/policies-and-procedures/software-components-list.html
-  "nginx-mod-http-naxsi=1.26.1-r0", \
-  "nginx-mod-http-xslt-filter=1.26.1-r0", \
+  "nginx-mod-http-naxsi=1.26.2-r0", \
+  "nginx-mod-http-xslt-filter=1.26.2-r0", \
   "openssl", \
   "tini" \
 ]


### PR DESCRIPTION
Noticed while we were updating the reverse proxy pipelines that the naxsi version has been updated and we can't build now. This bumps it to the latest patch version.