### PR TITLE
PP-13322: Remove the needless braces surrounding otherwise plain text logs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Testing Minimal Server..."
           curl --fail -sk -o /dev/null "https://localhost:10443"
           echo "Check the log output"
-          docker compose logs test-minimal  | grep -E '\{[^:]+:'10443' [0-9a-f]+ - [0-9.]+ - \[[0-9]+/[A-Z][a-z][a-z]/[0-9:]{13} \+[0-9]{4}\] "GET / HTTP/1\.1" [0-9]{3} [0-9]+ [0-9]+\.[0-9]{3} - "-" "[^"]+"\}'
+          docker compose logs test-minimal  | grep -E '[^:]+:'10443' [0-9a-f]+ - [0-9.]+ - \[[0-9]+/[A-Z][a-z][a-z]/[0-9:]{13} \+[0-9]{4}\] "GET / HTTP/1\.1" [0-9]{3} [0-9]+ [0-9]+\.[0-9]{3} - "-" "[^"]+"'
           echo "Test limited protcol and SSL cipher... "
           docker compose run --rm --entrypoint bash nginx -c "echo GET / | /usr/bin/openssl s_client -cipher 'AES256+EECDH' -tls1_2 -connect test-minimal:10443"  &> /dev/null;
           docker compose stop test-minimal

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,7 +74,7 @@ http {
       text/x-cross-domain-policy;
     # text/html is always compressed by HttpGzipModule
 
-    log_format extended '{$host:$server_port $uuid $http_x_forwarded_for $remote_addr $remote_user [$time_local] "$request" $status $body_bytes_sent $request_time $http_x_forwarded_proto "$http_referer" "$http_user_agent"}';
+    log_format extended '$host:$server_port $uuid $http_x_forwarded_for $remote_addr $remote_user [$time_local] "$request" $status $body_bytes_sent $request_time $http_x_forwarded_proto "$http_referer" "$http_user_agent"';
 
     map $request_uri $loggable {
       ~^/nginx_status/  0;


### PR DESCRIPTION
For unknown reasons we have curly braces surrounding our plain text logs.

The upstream home office version of this proxy creates a custom JSON format, I suspect there's been a misunderstanding when we implemented this.

Our log shipping code immediately removes any surrounding braces, and copes whether the log does or doesn't have the braces, so we can just get rid of them and remove one needless complexity in our logging config.

I will deploy this only to test and make sure splunk is correctly receiving the logs before allowing it to move to later envs.