### PR TITLE
PP-13582 Change logs to KV format

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Runs locally in about 4.5 minutes - if it takes longer than this, something has gone wrong.
-    timeout-minutes: 10 
+    timeout-minutes: 10
 
     defaults:
       run:
@@ -48,7 +48,7 @@ jobs:
           echo "Testing Minimal Server..."
           curl --fail -sk -o /dev/null "https://localhost:10443"
           echo "Check the log output"
-          docker compose logs test-minimal  | grep -E '[^:]+:'10443' [0-9a-f]+ - [0-9.]+ - \[[0-9]+/[A-Z][a-z][a-z]/[0-9:]{13} \+[0-9]{4}\] "GET / HTTP/1\.1" [0-9]{3} [0-9]+ [0-9]+\.[0-9]{3} - "-" "[^"]+"'
+          docker compose logs test-minimal  | grep -E 'server="[0-9a-z]+" dest_port="[0-9]+" dest_ip="[0-9.]+" src="[0-9.]+" src_ip="[0-9.]+" time_local="[0-9]+/[A-Z][a-z][a-z]/[0-9:]{13} \+[0-9]{4}" protocol="HTTP/1\.1" status="[0-9]{3}" bytes_out="[0-9]+" bytes_in="[0-9-]+" http_referer="" http_user_agent="curl/[0-9.]+" nginx_version="[0-9.]+" http_x_forwarded_for="-" http_x_header="-" uri_query="" uri_path="/" http_method="GET" response_time="-" request_time="[0-9.]+" category="text/html" https="" x_request_id=""'
           echo "Test limited protcol and SSL cipher... "
           docker compose run --rm --entrypoint bash nginx -c "echo GET / | /usr/bin/openssl s_client -cipher 'AES256+EECDH' -tls1_2 -connect test-minimal:10443"  &> /dev/null;
           docker compose stop test-minimal

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -93,13 +93,14 @@ location ${LOCATION} {
     include  ${NAXSI_LOCATION_RULES}/*.rules ;
 
     # We need to re-use these later, but cannot use include due to using variables.
-    set \$_request \$request;
-    if (\$_request ~ (.*)email=[^&+]*(.*)) {
-        set \$_request \$1email=****\$2;
-    }
     set \$_http_referer \$http_referer;
     if (\$_http_referer ~ (.*)email=[^&+]*(.*)) {
         set \$_http_referer \$1email=****\$2;
+    }
+
+    set \$_query_string \$query_string;
+    if (\$_query_string ~ (.*)email=[^&+]*(.*)) {
+        set \$_query_string \$1email=****\$2;
     }
 
     set \$backend_upstream "\$proxy_address";
@@ -123,7 +124,7 @@ cat << EOF_SERVERCACHE_CONF >> /etc/nginx/conf/locations/${LOCATION_ID}.conf
 location ~* ^${ESCAPED_LOCATION}(.+)\.(jpg|jpeg|gif|png|svg|ico|css|bmp|js|html|htm|ttf|otf|eot|woff|woff2|json)$ {
     proxy_cache staticcache;
     add_header X-Proxy-Cache \$upstream_cache_status;
-    
+
     # Nginx cache to ignore Node.js "Cache-Control: public, max-age=0"
     proxy_ignore_headers Cache-Control;
     proxy_hide_header Cache-Control;
@@ -139,13 +140,14 @@ location ~* ^${ESCAPED_LOCATION}(.+)\.(jpg|jpeg|gif|png|svg|ico|css|bmp|js|html|
     include  ${NAXSI_LOCATION_RULES}/*.rules ;
 
     # Re-use these again...
-    set \$_request \$request;
-    if (\$_request ~ (.*)email=[^&+]*(.*)) {
-        set \$_request \$1email=****\$2;
-    }
     set \$_http_referer \$http_referer;
     if (\$_http_referer ~ (.*)email=[^&+]*(.*)) {
         set \$_http_referer \$1email=****\$2;
+    }
+
+    set \$_query_string \$query_string;
+    if (\$_query_string ~ (.*)email=[^&+]*(.*)) {
+        set \$_query_string \$1email=****\$2;
     }
 
     set \$backend_upstream "\$proxy_address";

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,14 +74,21 @@ http {
       text/x-cross-domain-policy;
     # text/html is always compressed by HttpGzipModule
 
-    log_format extended '$host:$server_port $uuid $http_x_forwarded_for $remote_addr $remote_user [$time_local] "$request" $status $body_bytes_sent $request_time $http_x_forwarded_proto "$http_referer" "$http_user_agent"';
+    log_format key-value 'server="$host" dest_port="$server_port" dest_ip="$server_addr" src="$remote_addr" '
+                    'src_ip="$realip_remote_addr" time_local="$time_local" protocol="$server_protocol" status="$status" '
+                    'bytes_out="$bytes_sent" bytes_in="$upstream_bytes_received" http_referer="$_http_referer" '
+                    'http_user_agent="$http_user_agent" nginx_version="$nginx_version" '
+                    'http_x_forwarded_for="$http_x_forwarded_for" http_x_header="$http_x_header" '
+                    'uri_query="$_query_string" uri_path="$uri" http_method="$request_method" '
+                    'response_time="$upstream_response_time" request_time="$request_time" '
+                    'category="$sent_http_content_type" https="$https" x_request_id="$uuid"';
 
     map $request_uri $loggable {
       ~^/nginx_status/  0;
       default 1;
     }
 
-    access_log /dev/stdout extended if=$loggable;
+    access_log /dev/stdout key-value if=$loggable;
 
     include /etc/nginx/conf/upload_size*.conf;
     include /etc/nginx/conf/nginx_http_extras*.conf;


### PR DESCRIPTION
- Updates logs format to KV format

  Tested locally and below is the example log

>  server="localhost" dest_port="39000" dest_ip="172.18.0.16" src="172.18.0.1" src_ip="172.18.0.1" time_local="12/Feb/2025:19:05:28 +0000" protocol="HTTP/1.1" status="200" bytes_out="7583" bytes_in="27258" http_referer="https://localhost:39000/account/b0265cab2cc3439aa386682a670e3e8d/transactions?reference=&email=****&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=" http_user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36" nginx_version="1.26.2" http_x_forwarded_for="-" http_x_header="-" uri_query="reference=&email=****&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=" uri_path="/account/b0265cab2cc3439aa386682a670e3e8d/transactions" http_method="GET" response_time="0.536" request_time="0.535" category="text/html; charset=utf-8" https="on" http_x_forwarded_proto="-" x_request_id="231201de07f927fa93d43b586f78c676"


   current format

> localhost:39000 fb8b55068c7a3b2943719ad0ca226ec5 - 172.18.0.1 - [13/Feb/2025:08:58:18 +0000] "GET /account/b0265cab2cc3439aa386682a670e3e8d/transactions?reference=&email=test%40email.com&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue= HTTP/1.1" 200 7077 0.582 - "https://localhost:39000/account/b0265cab2cc3439aa386682a670e3e8d/transactions" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"

- `remote_user` (which is only available when basic auth is used) and `http_cookie` (which can log sensitive session cookie) are excluded from logs

- Note that the above also fixes email redaction
- Error logs format will stay the same
   naxsi error logs
   > 2025/02/13 09:22:23 [error] 39#39: *72 NAXSI_FMT: ip=172.18.0.1&server=localhost&uri=/account/b0265cab2cc3439aa386682a670e3e8d/transactions&vers=1.3&total_processed=57&total_blocked=1&config=block&cscore0=$SQL&score0=12&zone0=ARGS&id0=1000&var_name0=id, client: 172.18.0.1, server: $host, request: "GET /account/b0265cab2cc3439aa386682a670e3e8d/transactions?id=%22delete%20from%20table%22 HTTP/1.1", host: "localhost:39000"

    current naxsi logs
    > 2025/02/12 21:58:07 [error] 82#82: *26737 NAXSI_FMT: ip=3.17.16.51&server=ec2-xxxx.eu-west-1.compute.amazonaws.com&uri=/sdk&vers=1.3&total_processed=24120&total_blocked=8&config=block&zone0=BODY&id0=11&var_name0=, client: x.x.x.xx, server: $host, request: "POST /sdk HTTP/1.1", host: "ec2-xxxx.eu-west-1.compute.amazonaws.com"


- Depends on https://github.com/alphagov/cyber-security-splunk-apps/pull/974 being installed